### PR TITLE
Fixed a bug in the back button (package not reset) in package edit

### DIFF
--- a/app/controller/package/packageController.js
+++ b/app/controller/package/packageController.js
@@ -429,8 +429,7 @@
         };
 
         $scope.editPackageData = function (packageData) {
-            //$scope.packageObj = packageData;
-            $scope.packageObj = angular.merge(packageData, $scope.packageObj);
+            $scope.packageObj = packageData;
             $scope.onClickCollapsed('Update');
         };
 

--- a/app/views/package/package.html
+++ b/app/views/package/package.html
@@ -123,8 +123,9 @@
                             <label class="control-label col-md-3 col-sm-3 col-xs-12">Digin Templates</label>
                             <div class="col-md-4 col-sm-4 col-xs-12">
                                     <div class="checkbox" ng-repeat="d_template in diginTemplates">
-                                        <input type="checkbox" checklist-model="packageObj.sharedResources['DIGIN_CONSOLE']" checklist-value="d_template">
+                                        <label><input type="checkbox" checklist-model="packageObj.sharedResources['DIGIN_CONSOLE']" checklist-value="d_template">
                                         {{d_template.compName}}
+                                    </label>
                                     </div>
                             </div>
                         </div>


### PR DESCRIPTION
This bug was introduced after adding the shared resource option in package edit window. This commit fixes it.